### PR TITLE
Update Couler to v0.1.1rc8-stable to fix the import error

### DIFF
--- a/argo-workflows/python/create.md
+++ b/argo-workflows/python/create.md
@@ -1,6 +1,6 @@
 To install [Couler](https://github.com/couler-proj/couler) Python SDK, you need Python 3 and [pip](https://github.com/pypa/pip):
 
-`pip3 install git+https://github.com/couler-proj/couler@v0.1.1rc8`{{execute}}
+`pip3 install git+https://github.com/couler-proj/couler@v0.1.1rc8-stable`{{execute}}
 
 The following example combines the use of a Python function result, along with conditionals,
 to take a dynamic path in the workflow. In this example, depending on the result


### PR DESCRIPTION
`v0.1.1rc8-stable` includes a fix for import exception on `protobuf`. 

```
Traceback (most recent call last):
  File "coin_flip_example.py", line 1, in <module>
    import couler.argo as couler
  File "/usr/local/lib/python3.8/dist-packages/couler/__init__.py", line 14, in <module>
    from couler.argo import *  # noqa: F401, F403
  File "/usr/local/lib/python3.8/dist-packages/couler/argo.py", line 23, in <module>
    from couler.core import states  # noqa: F401
  File "/usr/local/lib/python3.8/dist-packages/couler/core/states.py", line 17, in <module>
    from couler.core.proto_repr import cleanup_proto_workflow
  File "/usr/local/lib/python3.8/dist-packages/couler/core/proto_repr.py", line 18, in <module>
    from couler.proto import couler_pb2
  File "/usr/local/lib/python3.8/dist-packages/couler/proto/couler_pb2.py", line 5, in <module>
    from google.protobuf import descriptor as _descriptor
ModuleNotFoundError: No module named 'google.protobuf'
```