### PR TITLE
Updating the URL for Katacoda LAB

### DIFF
--- a/argo-workflows/getting-started/ui.md
+++ b/argo-workflows/getting-started/ui.md
@@ -4,7 +4,7 @@ You can view the user interface by running a port forward:
 
 To check this is working correctly, you can curl the info API:
 
-`curl -kv http://localhost:2746/api/v1/info`{{execute}}
+`curl -kv https://localhost:2746/api/v1/info`{{execute}}
 
 You should see `HTTP/1.1 200 OK`.
 


### PR DESCRIPTION
Updating broken url in katakoda UI lab

fixes: https://github.com/argoproj-labs/katacoda-scenarios/issues/7